### PR TITLE
fix(typings): fixing unifiedSearchId type, string vs String;

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1833,7 +1833,7 @@ export interface Candidate {
     travelMethod?: Strings;
     twoJobs?: boolean;
     type?: Strings;
-    unifiedSearchId?: String;
+    unifiedSearchId?: string;
     userDateAdded?: Date;
     userIntegrations?: ToMany<UserIntegration>;
     userType?: UserType;


### PR DESCRIPTION
"_Type 'String' is not assignable to type 'string'.
'string' is a primitive, but 'String' is a wrapper object. Prefer using 'string' when possible._"